### PR TITLE
refactor: remove sushi and adapt for Filament v4 custom data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "filament/filament": "^4.0",
-        "calebporzio/sushi": "^2.5"
+        "filament/filament": "^4.0"
     },
     "require-dev": {
         "laravel/pint": "^1.23",

--- a/src/Filters/DateRangeFilter.php
+++ b/src/Filters/DateRangeFilter.php
@@ -26,15 +26,6 @@ final class DateRangeFilter
                     ->label('Until'),
             ])
             ->columns()
-            ->query(fn (Builder $query, array $data): Builder => $query
-                ->when(
-                    $data['from'],
-                    fn (Builder $query, $date): Builder => $query->whereDate($name, '>=', $date),
-                )
-                ->when(
-                    $data['until'],
-                    fn (Builder $query, $date): Builder => $query->whereDate($name, '<=', $date),
-                ))
             ->indicateUsing(
                 fn (array $data): array => self::indicators($data),
             );

--- a/src/Filters/DateRangeFilter.php
+++ b/src/Filters/DateRangeFilter.php
@@ -9,7 +9,6 @@ use Exception;
 use Filament\Forms\Components\DatePicker;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\Indicator;
-use Illuminate\Database\Eloquent\Builder;
 
 final class DateRangeFilter
 {

--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -75,13 +75,15 @@ final class LogTable extends Page implements HasTable
     {
         return $table
             ->records(
-                fn (?string $sortColumn, ?string $sortDirection): Collection => collect(Log::getRows())
+                fn (?array $filters): Collection => collect(Log::getRows())
+                    ->when(
+                        ! $this->tableIsUnscoped(),
+                        fn (Collection $data): Collection => $data->where(
+                            'log_level',
+                            $this->activeTab
+                        ),
+                    )
             )
-            ->modifyQueryUsing(function (Builder $query): void {
-                if (! $this->tableIsUnscoped()) {
-                    $query->where('log_level', $this->activeTab);
-                }
-            })
             ->columns([
                 TextColumn::make('log_level')
                     ->badge(),
@@ -101,14 +103,12 @@ final class LogTable extends Page implements HasTable
                     ->badge()
                     ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('message')
-                    ->searchable()
                     ->label('Summary')
                     ->wrap(),
                 TextColumn::make('date')
                     ->label('Occurred')
                     ->since()
-                    ->dateTimeTooltip()
-                    ->sortable(),
+                    ->dateTimeTooltip(),
             ])
             ->recordActions([
                 ViewAction::make('view')

--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -75,7 +75,7 @@ final class LogTable extends Page implements HasTable
     {
         return $table
             ->records(
-                fn (?array $filters): Collection => collect(Log::getRows())
+                fn (?array $filters, ?string $sortColumn, ?string $sortDirection): Collection => collect(Log::getRows())
                     ->when(
                         ! $this->tableIsUnscoped(),
                         fn (Collection $data): Collection => $data->where(
@@ -83,22 +83,30 @@ final class LogTable extends Page implements HasTable
                             $this->activeTab
                         ),
                     )
-                ->when(
-                    filled($filters['date']['from']),
-                    fn (Collection $data): Collection => $data->where(
-                        'date',
-                        '>=',
-                        $filters['date']['from']
+                    ->when(
+                        filled($filters['date']['from']),
+                        fn (Collection $data): Collection => $data->where(
+                            'date',
+                            '>=',
+                            $filters['date']['from']
+                        )
                     )
-                )
-                ->when(
-                    filled($filters['date']['until']),
-                    fn (Collection $data): Collection => $data->where(
-                        'date',
-                        '<=',
-                        $filters['date']['until']
+                    ->when(
+                        filled($filters['date']['until']),
+                        fn (Collection $data): Collection => $data->where(
+                            'date',
+                            '<=',
+                            $filters['date']['until']
+                        )
                     )
-                )
+                    ->when(
+                        filled($sortColumn),
+                        fn (Collection $data): Collection => $data->sortBy(
+                            $sortColumn,
+                            SORT_REGULAR,
+                            $sortDirection === 'desc',
+                        )
+                    )
             )
             ->columns([
                 TextColumn::make('log_level')
@@ -124,6 +132,7 @@ final class LogTable extends Page implements HasTable
                 TextColumn::make('date')
                     ->label('Occurred')
                     ->since()
+                    ->sortable()
                     ->dateTimeTooltip(),
             ])
             ->recordActions([

--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -23,6 +23,7 @@ use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 
 final class LogTable extends Page implements HasTable
 {
@@ -73,8 +74,8 @@ final class LogTable extends Page implements HasTable
     public function table(Table $table): Table
     {
         return $table
-            ->query(
-                Log::query()
+            ->records(
+                fn (?string $sortColumn, ?string $sortDirection): Collection => collect(Log::getRows())
             )
             ->modifyQueryUsing(function (Builder $query): void {
                 if (! $this->tableIsUnscoped()) {
@@ -147,7 +148,6 @@ final class LogTable extends Page implements HasTable
                     $this->refresh();
                 }),
             Action::make('clear')
-                ->visible(Log::query()->count() > 0)
                 ->label('Clear Logs')
                 ->icon(Heroicon::Trash)
                 ->color(Color::Red)

--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -83,6 +83,22 @@ final class LogTable extends Page implements HasTable
                             $this->activeTab
                         ),
                     )
+                ->when(
+                    filled($filters['date']['from']),
+                    fn (Collection $data): Collection => $data->where(
+                        'date',
+                        '>=',
+                        $filters['date']['from']
+                    )
+                )
+                ->when(
+                    filled($filters['date']['until']),
+                    fn (Collection $data): Collection => $data->where(
+                        'date',
+                        '<=',
+                        $filters['date']['until']
+                    )
+                )
             )
             ->columns([
                 TextColumn::make('log_level')

--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -22,7 +22,6 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 
 final class LogTable extends Page implements HasTable
@@ -108,14 +107,14 @@ final class LogTable extends Page implements HasTable
                         )
                     )
                     ->when(
-                            filled($search),
-                            fn (Collection $data): Collection => $data->filter(
-                                fn (array $log): bool => str_contains(
-                                    mb_strtolower($log['message']),
-                                    mb_strtolower($search)
-                                )
+                        filled($search),
+                        fn (Collection $data): Collection => $data->filter(
+                            fn (array $log): bool => str_contains(
+                                mb_strtolower($log['message']),
+                                mb_strtolower((string) $search)
                             )
                         )
+                    )
             )
             ->columns([
                 TextColumn::make('log_level')

--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -75,7 +75,7 @@ final class LogTable extends Page implements HasTable
     {
         return $table
             ->records(
-                fn (?array $filters, ?string $sortColumn, ?string $sortDirection): Collection => collect(Log::getRows())
+                fn (?array $filters, ?string $sortColumn, ?string $sortDirection, ?string $search): Collection => collect(Log::getRows())
                     ->when(
                         ! $this->tableIsUnscoped(),
                         fn (Collection $data): Collection => $data->where(
@@ -107,6 +107,15 @@ final class LogTable extends Page implements HasTable
                             $sortDirection === 'desc',
                         )
                     )
+                    ->when(
+                            filled($search),
+                            fn (Collection $data): Collection => $data->filter(
+                                fn (array $log): bool => str_contains(
+                                    mb_strtolower($log['message']),
+                                    mb_strtolower($search)
+                                )
+                            )
+                        )
             )
             ->columns([
                 TextColumn::make('log_level')
@@ -128,6 +137,7 @@ final class LogTable extends Page implements HasTable
                     ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('message')
                     ->label('Summary')
+                    ->searchable()
                     ->wrap(),
                 TextColumn::make('date')
                     ->label('Occurred')

--- a/src/Model/Log.php
+++ b/src/Model/Log.php
@@ -5,24 +5,10 @@ declare(strict_types=1);
 namespace AchyutN\FilamentLogViewer\Model;
 
 use AchyutN\FilamentLogViewer\Enums\LogLevel;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pipeline\Pipeline;
-use Sushi\Sushi;
 
-final class Log extends Model
+final class Log
 {
-    use Sushi;
-
-    /** @var string[] */
-    protected array $schema = [
-        'log_level' => 'string',
-        'date' => 'datetime',
-        'env' => 'string',
-        'message' => 'string',
-        'file' => 'string',
-        'stack' => 'string',
-    ];
-
     public static function destroyAllLogs(): void
     {
         $logFilePath = storage_path('logs');
@@ -40,7 +26,7 @@ final class Log extends Model
     }
 
     /** @return string[] */
-    public function getRows(): array
+    public static function getRows(): array
     {
         $logFilePath = storage_path('logs');
         if (! is_dir($logFilePath)) {
@@ -69,14 +55,14 @@ final class Log extends Model
 
             foreach ($lines as $line) {
                 if (preg_match('/^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\]/', $line) && $entryLines !== []) {
-                    $logs[] = $this->parseLogEntry($entryLines, $file);
+                    $logs[] = self::parseLogEntry($entryLines, $file);
                     $entryLines = [];
                 }
                 $entryLines[] = $line;
             }
 
             if ($entryLines !== []) {
-                $logs[] = $this->parseLogEntry($entryLines, $file);
+                $logs[] = self::parseLogEntry($entryLines, $file);
             }
         }
 
@@ -91,7 +77,7 @@ final class Log extends Model
         ];
     }
 
-    private function parseLogEntry(array $lines, string $file): ?array
+    private static function parseLogEntry(array $lines, string $file): ?array
     {
         $entry = implode("\n", $lines);
 
@@ -105,13 +91,13 @@ final class Log extends Model
             'date' => trim($matches['date']),
             'env' => trim($matches['env']),
             'log_level' => LogLevel::from(mb_strtolower(trim($matches['level']))),
-            'message' => $this->extractMessage($matches['message']),
-            'stack' => $this->extractStack($matches['message']),
+            'message' => self::extractMessage($matches['message']),
+            'stack' => self::extractStack($matches['message']),
             'file' => $file,
         ];
     }
 
-    private function extractMessage(string $raw): string
+    private static function extractMessage(string $raw): string
     {
         $split = preg_split('/\n|\{/', $raw, 2);
 
@@ -122,7 +108,7 @@ final class Log extends Model
         return trim($raw);
     }
 
-    private function extractStack(string $raw): string
+    private static function extractStack(string $raw): string
     {
         $stackTrace = app(Pipeline::class)
             ->send($raw)

--- a/src/Model/Log.php
+++ b/src/Model/Log.php
@@ -25,7 +25,7 @@ final class Log
         }
     }
 
-    /** @return string[] */
+    /** @return array<string, array<string, string>> */
     public static function getRows(): array
     {
         $logFilePath = storage_path('logs');
@@ -67,6 +67,32 @@ final class Log
         }
 
         return array_filter($logs);
+    }
+
+    public static function getLogsByLogLevel(string $logLevel = 'all-logs'): array
+    {
+        if ($logLevel === 'all-logs') {
+            return self::getRows();
+        }
+
+        $logLevelWise = [];
+        foreach (self::getRows() as $log) {
+            $logHasLogLevel = array_key_exists('log_level', $log) && $log['log_level'] instanceof LogLevel;
+            if ($logHasLogLevel && $log['log_level']->value === $logLevel) {
+                $logLevelWise[] = $log;
+            }
+        }
+
+        return $logLevelWise;
+    }
+
+    public static function getLogCount(string $logLevel = 'all-logs'): int
+    {
+        if ($logLevel === 'all-logs') {
+            return count(self::getRows());
+        }
+
+        return count(self::getLogsByLogLevel($logLevel));
     }
 
     protected function casts(): array

--- a/src/Model/Log.php
+++ b/src/Model/Log.php
@@ -95,14 +95,6 @@ final class Log
         return count(self::getLogsByLogLevel($logLevel));
     }
 
-    protected function casts(): array
-    {
-        return [
-            'log_level' => LogLevel::class,
-            'stack' => 'json',
-        ];
-    }
-
     private static function parseLogEntry(array $lines, string $file): ?array
     {
         $entry = implode("\n", $lines);

--- a/src/Traits/LogLevelTabFilter.php
+++ b/src/Traits/LogLevelTabFilter.php
@@ -35,16 +35,16 @@ trait LogLevelTabFilter
         $all_logs = [
             $this->unscopedLogLevel => Tab::make('All Logs')
                 ->id($this->unscopedLogLevel)
-//                ->badge(fn () => Log::query()->count() ?: null),
+                ->badge(fn () => Log::getLogCount() ?: null),
         ];
 
         $tabs = collect(LogLevel::cases())
             ->mapWithKeys(fn (LogLevel $level) => [
                 $level->value => Tab::make($level->getLabel())
                     ->id($level->value)
-//                    ->badge(
-//                        fn () => Log::query()->where('log_level', $level)->count() ?: null
-//                    )
+                    ->badge(
+                        fn () => Log::getLogCount($level->value) ?: null,
+                    )
                     ->badgeColor($level->getColor()),
             ])->toArray();
 

--- a/src/Traits/LogLevelTabFilter.php
+++ b/src/Traits/LogLevelTabFilter.php
@@ -35,16 +35,16 @@ trait LogLevelTabFilter
         $all_logs = [
             $this->unscopedLogLevel => Tab::make('All Logs')
                 ->id($this->unscopedLogLevel)
-                ->badge(fn () => Log::query()->count() ?: null),
+//                ->badge(fn () => Log::query()->count() ?: null),
         ];
 
         $tabs = collect(LogLevel::cases())
             ->mapWithKeys(fn (LogLevel $level) => [
                 $level->value => Tab::make($level->getLabel())
                     ->id($level->value)
-                    ->badge(
-                        fn () => Log::query()->where('log_level', $level)->count() ?: null
-                    )
+//                    ->badge(
+//                        fn () => Log::query()->where('log_level', $level)->count() ?: null
+//                    )
                     ->badgeColor($level->getColor()),
             ])->toArray();
 

--- a/src/Traits/LogLevelTabFilter.php
+++ b/src/Traits/LogLevelTabFilter.php
@@ -35,7 +35,7 @@ trait LogLevelTabFilter
         $all_logs = [
             $this->unscopedLogLevel => Tab::make('All Logs')
                 ->id($this->unscopedLogLevel)
-                ->badge(fn () => Log::getLogCount() ?: null),
+                ->badge(fn (): ?int => Log::getLogCount() ?: null),
         ];
 
         $tabs = collect(LogLevel::cases())
@@ -43,7 +43,7 @@ trait LogLevelTabFilter
                 $level->value => Tab::make($level->getLabel())
                     ->id($level->value)
                     ->badge(
-                        fn () => Log::getLogCount($level->value) ?: null,
+                        fn (): ?int => Log::getLogCount($level->value) ?: null,
                     )
                     ->badgeColor($level->getColor()),
             ])->toArray();


### PR DESCRIPTION
### Changed

- Removed `calebporzio/sushi` dependency as it's no longer necessary with Filament v4 custom data

### Breaking

This change is for Filament v4 compatibility and is not backward-compatible with Filament v3.