### PR TITLE
fix: return array values from filtered logs

### DIFF
--- a/src/FilamentLogViewer.php
+++ b/src/FilamentLogViewer.php
@@ -139,7 +139,7 @@ final class FilamentLogViewer implements Plugin
         return $this->evaluate($this->navigationUrl);
     }
 
-    public function getPollingTime(): string|null
+    public function getPollingTime(): ?string
     {
         return $this->evaluate($this->pollingTime);
     }

--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -152,7 +152,7 @@ final class LogTable extends Page implements HasTable
         ];
 
         $tabs = collect(LogLevel::cases())
-            ->mapWithKeys(fn (LogLevel $level) => [
+            ->mapWithKeys(fn (LogLevel $level): array => [
                 $level->value => Tab::make($level->getLabel())
                     ->badge(
                         fn () => Log::query()->where('log_level', $level)->count() ?: null

--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -148,14 +148,14 @@ final class LogTable extends Page implements HasTable
     {
         $all_logs = [
             null => Tab::make('All Logs')
-                ->badge(fn () => Log::query()->count() ?: null),
+                ->badge(fn (): int => Log::query()->count()),
         ];
 
         $tabs = collect(LogLevel::cases())
             ->mapWithKeys(fn (LogLevel $level): array => [
                 $level->value => Tab::make($level->getLabel())
                     ->badge(
-                        fn () => Log::query()->where('log_level', $level)->count() ?: null
+                        fn (): int => Log::query()->where('log_level', $level)->count()
                     )
                     ->badgeColor($level->getColor()),
             ])->toArray();

--- a/src/Model/Log.php
+++ b/src/Model/Log.php
@@ -80,7 +80,7 @@ final class Log extends Model
             }
         }
 
-        return array_filter($logs);
+        return array_values(array_filter($logs));
     }
 
     protected function casts(): array


### PR DESCRIPTION
Ensures that the returned logs are re-indexed with numeric keys.

Closes #53 