### PR TITLE
ci: Changes to PR Lint Github Action file

### DIFF
--- a/.github/workflows/prlint.yml
+++ b/.github/workflows/prlint.yml
@@ -20,7 +20,11 @@ jobs:
                 php: [ 8.3 ]
         steps:
             -   name: Checkout Code
-                uses: actions/checkout@v4
+                uses: actions/checkout@v5
+                with:
+                    ref: ${{ github.event.pull_request.head.ref }}
+                    repository: ${{ github.event.pull_request.head.repo.full_name }}
+                    fetch-depth: 0
 
             -   name: "Check PR title"
                 uses: amannn/action-semantic-pull-request@v5
@@ -36,7 +40,7 @@ jobs:
 
             -   name: "Install Composer Dependencies"
                 run: |
-                    composer install --no-interaction --prefer-dist --optimize-autoloader
+                    composer install --no-interaction --prefer-dist --optimize-autoloader --no-ansi --no-progress
 
             -   name: "Run Rector"
                 run: |


### PR DESCRIPTION
- Upgraded [actions/checkout](https://github.com/actions/checkout) to version 5
- Adjusted composer install command to include `--no-ansi` and `--no-progress` flags.