### PR TITLE
fix: normalizes path separators before removing logs prefix

### DIFF
--- a/src/Model/Log.php
+++ b/src/Model/Log.php
@@ -149,7 +149,8 @@ final class Log
             $path = $directory.DIRECTORY_SEPARATOR.$item;
             $pathAfterRemovingStoragePath = str_replace(storage_path(), '', $path);
             $pathAfterRemovingFileName = str_replace(basename($path), '', $pathAfterRemovingStoragePath);
-            $pathWithoutLogsPrefix = str_replace('/logs/', '', $pathAfterRemovingFileName);
+            $normalized = str_replace('\\', '/', $pathAfterRemovingFileName);
+            $pathWithoutLogsPrefix = str_replace('/logs/', '', $normalized);
 
             if (is_dir($path)) {
                 $files = array_merge($files, self::getNestedFiles($path));


### PR DESCRIPTION
**This PR fixes a bug that prevented the log viewer from correctly detecting files and paths when the application runs on Windows.**

### Summary
On Windows, paths returned by storage_path() use backslashes (\), while the code was looking for the string prefix '/logs/' (with forward slashes). As a result, the replacement failed and the resulting paths were incorrect or not normalized.

### Problem

Observed behavior: On Windows, nested log files were not properly represented in the list (or the logs/ prefix was not removed), leading to incorrect/duplicate entries or broken filters.

Cause: String comparison was sensitive to the separator (/), but PHP (and storage_path()) on Windows uses \. The original code only checked for '/logs/', which could not be matched in Windows paths.

### What I changed
I normalize separators by converting all backslashes (\) to forward slashes (/) before removing the logs prefix. This ensures that:

Behavior is consistent across Windows, macOS, and Linux.

Prefix removal is explicit and more readable.

Literal `\\logs\\` patterns with excessive escaping are avoided, improving clarity.