### PR TITLE
feat: adds Enum support in navigation group

### DIFF
--- a/src/FilamentLogViewer.php
+++ b/src/FilamentLogViewer.php
@@ -8,6 +8,7 @@ use AchyutN\FilamentLogViewer\Traits\PluginVariables;
 use Closure;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
+use UnitEnum;
 
 final class FilamentLogViewer implements Plugin
 {
@@ -66,7 +67,7 @@ final class FilamentLogViewer implements Plugin
         return $this;
     }
 
-    public function navigationGroup(string|Closure $group): self
+    public function navigationGroup(string|UnitEnum|Closure $group): self
     {
         $this->navigationGroup = $group;
 

--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -27,6 +27,7 @@ use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
+use UnitEnum;
 
 /**
  * @phpstan-import-type LogRow from Log
@@ -48,7 +49,7 @@ final class LogTable extends Page implements HasTable
     }
 
     /** @throws Exception */
-    public static function getNavigationGroup(): string
+    public static function getNavigationGroup(): string|UnitEnum|null
     {
         return self::getPlugin()->getNavigationGroup();
     }

--- a/src/Traits/PluginVariables.php
+++ b/src/Traits/PluginVariables.php
@@ -33,6 +33,7 @@ trait PluginVariables
 
     public function getNavigationGroup(): string|UnitEnum|null
     {
+        /** @var string|UnitEnum|null */
         return $this->evaluate($this->navigationGroup);
     }
 

--- a/src/Traits/PluginVariables.php
+++ b/src/Traits/PluginVariables.php
@@ -6,6 +6,7 @@ namespace AchyutN\FilamentLogViewer\Traits;
 
 use Closure;
 use Filament\Support\Concerns\EvaluatesClosures;
+use UnitEnum;
 
 trait PluginVariables
 {
@@ -13,7 +14,7 @@ trait PluginVariables
 
     public bool|Closure $authorized = true;
 
-    public string|Closure|null $navigationGroup = null;
+    public string|UnitEnum|Closure|null $navigationGroup = null;
 
     public string|Closure $navigationIcon = 'heroicon-o-document-text';
 
@@ -30,10 +31,9 @@ trait PluginVariables
         return (bool) $this->evaluate($this->authorized);
     }
 
-    public function getNavigationGroup(): string
+    public function getNavigationGroup(): string|UnitEnum|null
     {
-        /** @phpstan-var string */
-        return $this->evaluate($this->navigationGroup) ?? '';
+        return $this->evaluate($this->navigationGroup);
     }
 
     public function getNavigationIcon(): string


### PR DESCRIPTION
In Filament v4 it is possible to use an enum class in `$navigationGroup` on pages.

This change updates the plug-in to have consistent behaviour with Filament and also solves the bug of duplicate navigation groups being present due to mixing enum classes and strings.