### PR TITLE
feat: adds log viewer plugin retrieval logic

### DIFF
--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -196,7 +196,12 @@ final class LogTable extends Page implements HasTable
     private static function getPlugin(): FilamentLogViewer
     {
         $panel = Filament::getCurrentPanel();
+        $logViewer = FilamentLogViewer::make();
 
-        return $panel?->getPlugin('filament-log-viewer');
+        if ($panel->hasPlugin($logViewer->getId())) {
+            return $panel->getPlugin($logViewer->getId());
+        }
+
+        return $logViewer;
     }
 }


### PR DESCRIPTION
Enhances the method to return the log viewer plugin, ensuring it checks for the plugin's existence in the current panel 
before instantiating a new one.

Closes #75 