### PR TITLE
fix: route registration when using custom URL

### DIFF
--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -233,9 +233,9 @@ final class LogTable extends Page implements HasTable
     }
 
     /** @throws Exception */
-    private static function getPlugin(): FilamentLogViewer
+    private static function getPlugin(?Panel $panel = null): FilamentLogViewer
     {
-        $panel = Filament::getCurrentPanel();
+        $panel ??= Filament::getCurrentPanel();
         $logViewer = FilamentLogViewer::make();
 
         if ($panel?->hasPlugin($logViewer->getId())) {

--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -65,7 +65,7 @@ final class LogTable extends Page implements HasTable
     public static function getSlug(?Panel $panel = null): string
     {
         return ltrim(
-            self::getPlugin()->getNavigationUrl(),
+            self::getPlugin($panel)->getNavigationUrl(),
             '/'
         );
     }


### PR DESCRIPTION
After updating to the latest version I was getting an issue with my route not being registered correctly for the plugin. 

I am using `navigationUrl()` to set `/developer-tools/logs` as the URL, I would get a `Route [filament.tenant.pages.developer-tools.logs] not defined` when logging into my panel. 

This was caused by the changes made in https://github.com/achyutkneupane/filament-log-viewer/pull/83 causing the route to not be registered against the correct panel.

The fix is to pass the panel through to the `getPlugin()` method from the `getSlug()` rather than relying on the panel returned from `Filament::getCurrentPanel()`