### PR TITLE
feat: Clear log button option

### DIFF
--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -217,7 +217,7 @@ final class LogTable extends Page implements HasTable
                 ->action(function (): void {
                     $this->refresh();
                 }),
-            Action::make('clear')
+            ...(config('filament-log-viewer.enable_delete', true) ? Action::make('clear')
                 ->label(__('filament-log-viewer::log.table.actions.clear.label'))
                 ->icon(Heroicon::Trash)
                 ->color(Color::Red)
@@ -228,7 +228,7 @@ final class LogTable extends Page implements HasTable
                         ->title(__('filament-log-viewer::log.table.actions.clear.success'))
                         ->success()
                         ->send();
-                }),
+                }) : []),
         ];
     }
 

--- a/src/config/filament-log-viewer.php
+++ b/src/config/filament-log-viewer.php
@@ -12,4 +12,5 @@ return [
     | Files larger than this will be skipped to prevent memory exhaustion.
     */
     'max_log_file_size' => env('LOG_MAX_SIZE_KB', 2048),
+    'enable_delete' => env('LOG_ENABLE_DELETE', true),
 ];


### PR DESCRIPTION
Sometimes you want to use the log as an audit log and want to preserve the integrity of the history, perhaps if you are logging user activity. I don't want admins to be able to clear the log from the admin panel. This pull request adds an additional option to disable the clear button if desired. Simply add `LOG_ENABLE_DELETE=false` to your `.env` or in `config/filament-log-viewer.php`, `'enable_delete' => env('LOG_ENABLE_DELETE', false),`. The default is true and will remain visible.