### PR TITLE
feat: adds config to show or hide clear button

### DIFF
--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -217,22 +217,19 @@ final class LogTable extends Page implements HasTable
                 ->action(function (): void {
                     $this->refresh();
                 }),
-            ...(config('filament-log-viewer.enable_delete', true) ?
-                [
-                    Action::make('clear')
-                    ->label(__('filament-log-viewer::log.table.actions.clear.label'))
-                    ->icon(Heroicon::Trash)
-                    ->color(Color::Red)
-                    ->requiresConfirmation()
-                    ->action(function (): void {
-                        Log::destroyAllLogs();
-                        Notification::make()
-                            ->title(__('filament-log-viewer::log.table.actions.clear.success'))
-                            ->success()
-                            ->send();
-                    }),
-                ]
-                : []),
+            Action::make('clear')
+                ->label(__('filament-log-viewer::log.table.actions.clear.label'))
+                ->icon(Heroicon::Trash)
+                ->color(Color::Red)
+                ->visible(fn () => config('filament-log-viewer.enable_delete', true))
+                ->requiresConfirmation()
+                ->action(function (): void {
+                    Log::destroyAllLogs();
+                    Notification::make()
+                        ->title(__('filament-log-viewer::log.table.actions.clear.success'))
+                        ->success()
+                        ->send();
+                }),
         ];
     }
 

--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -217,7 +217,7 @@ final class LogTable extends Page implements HasTable
                 ->action(function (): void {
                     $this->refresh();
                 }),
-            Action::make('clear')
+            ...(config('filament-log-viewer.enable_delete', true) ? Action::make('clear')
                 ->label(__('filament-log-viewer::log.table.actions.clear.label'))
                 ->icon(Heroicon::Trash)
                 ->color(Color::Red)
@@ -228,7 +228,7 @@ final class LogTable extends Page implements HasTable
                         ->title(__('filament-log-viewer::log.table.actions.clear.success'))
                         ->success()
                         ->send();
-                }),
+                }) : []),
         ];
     }
 

--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -217,18 +217,22 @@ final class LogTable extends Page implements HasTable
                 ->action(function (): void {
                     $this->refresh();
                 }),
-            ...(config('filament-log-viewer.enable_delete', true) ? Action::make('clear')
-                ->label(__('filament-log-viewer::log.table.actions.clear.label'))
-                ->icon(Heroicon::Trash)
-                ->color(Color::Red)
-                ->requiresConfirmation()
-                ->action(function (): void {
-                    Log::destroyAllLogs();
-                    Notification::make()
-                        ->title(__('filament-log-viewer::log.table.actions.clear.success'))
-                        ->success()
-                        ->send();
-                }) : []),
+            ...(config('filament-log-viewer.enable_delete', true) ?
+                [
+                    Action::make('clear')
+                    ->label(__('filament-log-viewer::log.table.actions.clear.label'))
+                    ->icon(Heroicon::Trash)
+                    ->color(Color::Red)
+                    ->requiresConfirmation()
+                    ->action(function (): void {
+                        Log::destroyAllLogs();
+                        Notification::make()
+                            ->title(__('filament-log-viewer::log.table.actions.clear.success'))
+                            ->success()
+                            ->send();
+                    }),
+                ]
+                : []),
         ];
     }
 

--- a/src/config/filament-log-viewer.php
+++ b/src/config/filament-log-viewer.php
@@ -12,4 +12,5 @@ return [
     | Files larger than this will be skipped to prevent memory exhaustion.
     */
     'max_log_file_size' => env('LOG_MAX_SIZE_KB', 2048),
+    'enable_delete' => env('LOG_ENABLE_DELETE', true),
 ];

--- a/tests/Feature/LogTableTest.php
+++ b/tests/Feature/LogTableTest.php
@@ -7,6 +7,7 @@ namespace AchyutN\FilamentLogViewer\Tests\Feature;
 use AchyutN\FilamentLogViewer\LogTable;
 use AchyutN\FilamentLogViewer\Model\Log;
 use Carbon\Carbon;
+use Config;
 use Filament\Actions\Action;
 use Filament\Support\Colors\Color;
 use Filament\Support\Icons\Heroicon;
@@ -38,6 +39,13 @@ describe('actions', function () {
                     ! $action->isOutlined() &&
                     $action->getColor() === Color::Red;
             });
+    });
+
+    it('hides clear action when config set to false', function () {
+        Config::set('filament-log-viewer.enable_delete', false);
+
+        livewire(LogTable::class)
+            ->assertActionExists('clear', fn (Action $action) => ! $action->isVisible());
     });
 
     it("refreshes logs on 'refresh' action", function () {


### PR DESCRIPTION
Sometimes you want to use the log as an audit log and want to preserve the integrity of the history, perhaps if you are logging user activity. I don't want admins to be able to clear the log from the admin panel. This pull request adds an additional option to disable the clear button if desired. Simply add `LOG_ENABLE_DELETE=false` to your `.env` or in `config/filament-log-viewer.php` add `'enable_delete' => env('LOG_ENABLE_DELETE', false)`. The default is `true` and will remain visible.