### PR TITLE
feat: adds support for disabling plugin navigation registration

### DIFF
--- a/src/FilamentLogViewer.php
+++ b/src/FilamentLogViewer.php
@@ -23,6 +23,7 @@ final class FilamentLogViewer implements Plugin
         $plugin->navigationSort($plugin->getNavigationSort());
         $plugin->navigationUrl($plugin->getNavigationUrl());
         $plugin->pollingTime($plugin->getPollingTime());
+        $plugin->registerNavigation($plugin->shouldRegisterNavigation());
 
         $navigationGroup = $plugin->getNavigationGroup();
         $navigationLabel = $plugin->getNavigationLabel();
@@ -105,6 +106,13 @@ final class FilamentLogViewer implements Plugin
     public function pollingTime(string|null|Closure $time): self
     {
         $this->pollingTime = $time;
+
+        return $this;
+    }
+
+    public function registerNavigation(bool $registerNavigation = true): self
+    {
+        $this->registerNavigation = $registerNavigation;
 
         return $this;
     }

--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -77,6 +77,12 @@ final class LogTable extends Page implements HasTable
     }
 
     /** @throws Exception */
+    public static function shouldRegisterNavigation(): bool
+    {
+        return self::getPlugin()->shouldRegisterNavigation();
+    }
+
+    /** @throws Exception */
     public static function canAccess(): bool
     {
         return self::getPlugin()->isAuthorized();

--- a/src/Traits/PluginVariables.php
+++ b/src/Traits/PluginVariables.php
@@ -26,6 +26,8 @@ trait PluginVariables
 
     public string|null|Closure $pollingTime = null;
 
+    public bool|null|Closure $registerNavigation = true;
+
     public function isAuthorized(): bool
     {
         return (bool) $this->evaluate($this->authorized);
@@ -65,5 +67,11 @@ trait PluginVariables
     {
         /** @var string|null */
         return $this->evaluate($this->pollingTime);
+    }
+
+    public function shouldRegisterNavigation(): bool
+    {
+        /** @var bool */
+        return (bool) $this->evaluate($this->registerNavigation);
     }
 }

--- a/src/Traits/PluginVariables.php
+++ b/src/Traits/PluginVariables.php
@@ -71,7 +71,6 @@ trait PluginVariables
 
     public function shouldRegisterNavigation(): bool
     {
-        /** @var bool */
         return (bool) $this->evaluate($this->registerNavigation);
     }
 }


### PR DESCRIPTION
## Summary

Adds support for disabling the plugin's navigation registration.

This makes it possible to use the log viewer without automatically showing it in the Filament sidebar.

## Example

```php
FilamentLogViewer::make()
    ->registerNavigation(false);