### PR TITLE
docs: updates Laravel Boost skill with extension guide

### DIFF
--- a/resources/boost/skills/filament-log-viewer-development/SKILL.md
+++ b/resources/boost/skills/filament-log-viewer-development/SKILL.md
@@ -1,90 +1,54 @@
 ---
 name: filament-log-viewer-development
-description: Build and work with Filament Log Viewer plugin for Filament v5.
+description: Build, customize, and extend the Filament Log Viewer plugin for Filament v5, including swapping providers, parsers, schemas, actions, and pages through its contract-driven API.
+license: MIT
 tags:
   - filament
   - laravel
   - logs
   - developer-tool
+  - extensibility
+metadata:
+  author: Achyut Neupane
 ---
 
 # Filament Log Viewer Development
 
-Use this skill when working with the Filament Log Viewer package - a Filament plugin to view and manage Laravel log files.
-
 ## Context
 
-A developer-focused Laravel log viewer with stack trace inspection, built for Filament v3 to v5. Provides:
-
-- Log table with searchable entries from `storage/logs`
-- Stack trace inspection in slide-over modals
-- Mail log preview for email logged entries
-- Multiple filter types (log level tabs, date range, file)
-- Dark mode ready
-- Multilingual support (English, Arabic, German, Spanish, Persian, French, Hebrew, Italian, Portuguese)
-- Copy log entries as formatted Markdown strings
-- Visit `/logs` in your Filament panel after installation
+You are working in a Laravel app using `achyutn/filament-log-viewer` — a Filament v5 plugin to view and manage Laravel log files with stack traces, mail previews, filtering, and a contract-driven API for swapping the page, provider, parsers, schemas, and actions.
 
 ## Rules
 
-### Version Compatibility
+- Version compatibility: `^2.x` targets Filament v5 (PHP ≥8.2), `^1.x` targets v4, `^0.x` targets v3.
+- Register the plugin on the panel with `->plugins([FilamentLogViewer::make()])` (`src/FilamentLogViewer.php`).
+- Customize navigation via `->navigationGroup()`, `->navigationIcon()` (string or `Heroicon` enum), `->navigationLabel()`, `->navigationSort()`, `->navigationUrl()`, and `->registerNavigation(false)` to hide it from the sidebar (`src/Traits/PluginVariables.php`, `src/Traits/HasLogViewerNavigation.php`).
+- Control access with `->authorize()`; never leave the viewer open to all users.
+- The table lives at `/logs` and supports log-level tabs, date/file filters, and a per-file clear dropdown.
+- Every component is replaceable through a plugin override method by implementing its contract or extending the non-final default (`src/Traits/PluginVariables.php`).
+- A provider that can delete logs must implement `CanDeleteLogs`; read-only providers (Pail, cloud readers) omit it and the clear buttons are hidden automatically (`src/Contracts/CanDeleteLogs.php`).
+- `AchyutN\FilamentLogViewer\Model\Log` remains as a backward-compatible static facade delegating to the container-resolved `LogProvider`; prefer the contract in new code (`src/Model/Log.php`).
 
-Always use the correct package version for your Filament version:
+## Extending
 
-| Package Version | Filament Version | PHP  |
-|-----------------|------------------|------|
-| `^2.x`          | v5               | ≥8.2 |
-| `^1.x`          | v4               | ≥8.1 |
-| `^0.x`          | v3               | ≥8.0 |
+Contracts and their defaults:
 
-### Customizations
+| Contract | Default | Plugin override |
+|---|---|---|
+| `LogProvider` | `LocalLogProvider` | `providerClass()` |
+| `LogParser` | `FileLogParser` | `parserClass()` |
+| `MailParser` | `DefaultMailParser` | `mailParserClass()` |
+| `StackTraceParser` | `DefaultStackTraceParser` | `stackTraceParserClass()` |
+| `LogViewerPage` | `LogTable` | `pageClass()` |
+| `CanDeleteLogs` | (implemented by `LocalLogProvider`) | — |
+| `LogTableSchemaInterface` | `LogTableSchema` | `tableSchemaClass()` |
+| `LogEntrySchemaInterface` | `ErrorLogSchema`, `JSONLogSchema`, `MailLogSchema` | `errorSchemaClass()`, `jsonSchemaClass()`, `mailSchemaClass()` |
 
-#### Authorization
+Additional overrides: `copyMarkdownActionClass()`, `dateRangeFilterClass()`, `fileFilterClass()`.
 
-Use the `->authorize()` method to control access to the Log Viewer page. You can pass a `Closure` that returns a boolean based on your authorization logic.
+Copy/paste examples for every contract: `references/code-examples.md`. Provider examples by type: `references/providers/read-only-provider.md` and `references/providers/database-provider.md`.
 
-#### Navigation Registration
-
-By default, the Log Viewer will be registered in the Filament sidebar navigation. You can disable this with `->registerNavigation(false)` if you want to link to it directly without showing it in the sidebar.
-
-#### Navigation Customization
-
-You can customize the navigation group, icon, label, sort order, and URL using the respective methods: `->navigationGroup()`, `->navigationIcon()`, `->navigationLabel()`, `->navigationSort()`, and `->navigationUrl()` respectively.
-
-#### Polling Time
-
-The `->pollingTime()` method allows you to set how often the log table should refresh to show new log entries. You can specify this in seconds (e.g., `'60s'`) or set it to `null` to disable polling.
-
-### Production Security
-
-1. **Disable Log Deletion**: Set `LOG_ENABLE_DELETE=false` in production to prevent accidental log deletion.
-
-```php
-// config/filament-log-viewer.php
-'enable_delete' => env('LOG_ENABLE_DELETE', false),
-```
-
-Or in `.env`:
-```
-LOG_ENABLE_DELETE=false
-```
-
-2. **Authorization**: Always use `->authorize()` closure for access control - never leave it open to all users.
-
-```php
-FilamentLogViewer::make()
-    ->authorize(fn (): bool => auth()->user()->is_admin);
-```
-
-### Performance
-
-1. **File Size Limit**: Adjust `LOG_MAX_SIZE_KB` based on available server memory. Default is 2MB.
-
-2. **Disable Polling**: Set `->pollingTime(null)` in production to reduce server load.
-
-```php
-->pollingTime(null) // Disable auto-refresh in production
-```
+> **The row shape.** Every row a provider returns is the `LogRow` array shape (`date`, `env`, `log_level`, `message`, `description`, `context`, `raw_stack`, `has_stack`, `mail`, `file`), and the default table renders those keys. For a database-backed provider, `file` carries the source/channel identifier of each row. To use a completely custom DTO/object shape with your own table design, supply your own page via `pageClass()` — see `references/custom-viewer.md`.
 
 ## Examples
 
@@ -109,23 +73,17 @@ return $panel
 
 ```php
 use AchyutN\FilamentLogViewer\FilamentLogViewer;
+use Filament\Support\Icons\Heroicon;
 
 FilamentLogViewer::make()
     ->authorize(fn (): bool => auth()->user()->is_admin)
     ->registerNavigation(true)
     ->navigationGroup('System')
-    ->navigationIcon('heroicon-o-document-text')
+    ->navigationIcon(Heroicon::OutlinedDocument)
     ->navigationLabel('Log Viewer')
     ->navigationSort(10)
     ->navigationUrl('/logs')
     ->pollingTime('60s');
-```
-
-### Authorization with Filament Shield
-
-```php
-FilamentLogViewer::make()
-    ->authorize(fn (): bool => auth()->check() && auth()->user()->can('View:LogTable'));
 ```
 
 ### Publish Configuration
@@ -141,38 +99,26 @@ return [
     'max_log_file_size' => env('LOG_MAX_SIZE_KB', 2048),
     'enable_delete' => env('LOG_ENABLE_DELETE', true),
     'enable_copy_markdown' => env('LOG_ENABLE_COPY_MARKDOWN', true),
+    'disable_cache' => env('LOG_DISABLE_CACHE', false),
     'copy_markdown_levels' => explode(',', env('LOG_COPY_MARKDOWN_LEVELS', 'error')),
 ];
 ```
 
-### Copy as Markdown Configuration
+Available log levels: `error`, `warning`, `critical`, `alert`, `emergency`, `info`, `notice`, `debug`, `mail`.
 
-Control which log levels show the "Copy as Markdown" button:
+## Anti-patterns / Gotchas
 
-```php
-// Only error logs (default)
-LOG_COPY_MARKDOWN_LEVELS=error
-
-// Multiple levels
-LOG_COPY_MARKDOWN_LEVELS=error,mail,warning
-
-// Or in config
-'copy_markdown_levels' => ['error', 'mail'],
-```
-
-Available log levels: `error`, `warning`, `critical`, `alert`, `emergency`, `info`, `notice`, `debug`, `mail`
-
-## Anti-patterns
-
-- Using wrong package version for your Filament version - always check compatibility table
-- Not disabling `enable_delete` in production - risks accidental log deletion
-- Missing `authorize()` check - exposes logs to all users including customers
-- Setting very large `max_log_file_size` without considering memory constraints
-- Leaving polling enabled in production without considering server load
-- Not configuring `copy_markdown_levels` for your use case - defaults to error only
+- Using the wrong package version for your Filament version — always check the compatibility table.
+- Not disabling `enable_delete` in production — risks accidental log deletion.
+- Missing `authorize()` — exposes logs to all users including customers.
+- Implementing `CanDeleteLogs` on a read-only provider — shows misleading clear buttons.
+- Calling `Log::getRows()` and other `Log::` statics in new code — prefer the `LogProvider` contract or a plugin override.
+- Overriding a default class without respecting its non-final, `protected`-hook convention.
+- Setting very large `max_log_file_size` without considering memory constraints.
 
 ## References
 
 - Official Documentation: https://filamentphp.com/plugins/achyutn-log-viewer
 - GitHub Repository: https://github.com/achyutkneupane/filament-log-viewer
 - Laravel Boost: https://laravel.com/docs/boost
+- Skill examples: `resources/boost/skills/filament-log-viewer-development/references/`

--- a/resources/boost/skills/filament-log-viewer-development/references/code-examples.md
+++ b/resources/boost/skills/filament-log-viewer-development/references/code-examples.md
@@ -1,0 +1,222 @@
+---
+name: filament-log-viewer-code-examples
+description: Copy/paste examples for custom parsers, schemas, and pages in the achyutn/filament-log-viewer package. Provider examples live in references/providers.
+license: MIT
+tags:
+  - filament
+  - logs
+  - extensibility
+metadata:
+  author: Achyut Neupane
+---
+
+# Filament Log Viewer Code Examples
+
+## Context
+
+These examples customize the non-provider contracts of `achyutn/filament-log-viewer`. Every default implementation is non-final with `protected` extension points, so you can extend a default and override a single behavior instead of reimplementing a contract. Provider examples live in `references/providers/`.
+
+> Parsers and providers exchange rows as the `LogRow` array shape (`date`, `env`, `log_level`, `message`, `description`, `context`, `raw_stack`, `has_stack`, `mail`, `file`). The table columns and modal schemas read those exact keys. For a fully custom DTO/object shape with your own table, see `references/custom-viewer.md`.
+
+## Examples
+
+### 1) LogParser — custom parser
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\LogParsers;
+
+use AchyutN\FilamentLogViewer\Parsers\FileLogParser;
+
+final class CustomLogParser extends FileLogParser
+{
+    public function isMailEntry(string $message): bool
+    {
+        // Custom mail detection for your log format.
+        return str_contains($message, 'X-Mailer:');
+    }
+}
+```
+
+Register it:
+
+```php
+use AchyutN\FilamentLogViewer\FilamentLogViewer;
+
+FilamentLogViewer::make()->parserClass(CustomLogParser::class);
+```
+
+### 2) MailParser — custom mail parser
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\LogParsers;
+
+use AchyutN\FilamentLogViewer\Parsers\DefaultMailParser;
+
+final class CustomMailParser extends DefaultMailParser
+{
+    public function isMailStack(?string $logStack): bool
+    {
+        if (! $logStack) {
+            return false;
+        }
+
+        return str_contains($logStack, 'X-Mailer:');
+    }
+}
+```
+
+Register it:
+
+```php
+use AchyutN\FilamentLogViewer\FilamentLogViewer;
+
+FilamentLogViewer::make()->mailParserClass(CustomMailParser::class);
+```
+
+### 3) StackTraceParser — custom stack trace parser
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\LogParsers;
+
+use AchyutN\FilamentLogViewer\Parsers\DefaultStackTraceParser;
+
+final class CustomStackTraceParser extends DefaultStackTraceParser
+{
+    public function hasStack(string $raw): bool
+    {
+        return str_contains($raw, 'Trace:') || parent::hasStack($raw);
+    }
+}
+```
+
+Register it:
+
+```php
+use AchyutN\FilamentLogViewer\FilamentLogViewer;
+
+FilamentLogViewer::make()->stackTraceParserClass(CustomStackTraceParser::class);
+```
+
+### 4) LogViewerPage — custom page
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\LogTables;
+
+use AchyutN\FilamentLogViewer\LogTable;
+use Filament\Actions\Action;
+
+final class CustomLogTable extends LogTable
+{
+    protected function getHeaderActions(): array
+    {
+        // Swap or extend the header actions.
+        return [...parent::getHeaderActions(), Action::make('export')];
+    }
+}
+```
+
+Register it:
+
+```php
+use AchyutN\FilamentLogViewer\FilamentLogViewer;
+
+FilamentLogViewer::make()->pageClass(CustomLogTable::class);
+```
+
+### 5) LogTableSchemaInterface — custom table columns
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\LogSchemas;
+
+use AchyutN\FilamentLogViewer\Contracts\Schema\LogTableSchemaInterface;
+use Filament\Tables\Columns\Column;
+use Filament\Tables\Columns\TextColumn;
+
+final class MyLogTableSchema implements LogTableSchemaInterface
+{
+    /** @return array<Column> */
+    public function getColumns(): array
+    {
+        return [
+            TextColumn::make('message')->label('Summary')->wrap(),
+            TextColumn::make('date')->label('Occurred')->since(),
+        ];
+    }
+}
+```
+
+Register it:
+
+```php
+use AchyutN\FilamentLogViewer\FilamentLogViewer;
+
+FilamentLogViewer::make()->tableSchemaClass(MyLogTableSchema::class);
+```
+
+### 6) LogEntrySchemaInterface — custom modal schema
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\LogSchemas;
+
+use AchyutN\FilamentLogViewer\Contracts\Schema\LogEntrySchemaInterface;
+use Filament\Schemas\Schema;
+
+final class MyErrorLogSchema implements LogEntrySchemaInterface
+{
+    public function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->key('error-log')
+            ->schema([
+                // Your infolist components.
+            ]);
+    }
+}
+```
+
+Register it:
+
+```php
+use AchyutN\FilamentLogViewer\FilamentLogViewer;
+
+FilamentLogViewer::make()->errorSchemaClass(MyErrorLogSchema::class);
+```
+
+## Anti-patterns / Gotchas
+
+- Extend the non-final defaults and override `protected` hooks instead of reimplementing a contract from scratch when you only need one change.
+- Overrides are resolved through Laravel's service container, so constructor dependencies are auto-wired; keep constructor signatures compatible.
+- The plugin is a container singleton, so overrides apply app-wide rather than per-panel.
+
+## References
+
+- Contracts: `src/Contracts/*`
+- Parsers: `src/Parsers/*`
+- Schemas: `src/Schema/*`
+- Page: `src/LogTable.php`
+- Skill: `resources/boost/skills/filament-log-viewer-development/SKILL.md`
+- Provider examples: `references/providers/*`

--- a/resources/boost/skills/filament-log-viewer-development/references/custom-viewer.md
+++ b/resources/boost/skills/filament-log-viewer-development/references/custom-viewer.md
@@ -1,0 +1,313 @@
+---
+name: filament-log-viewer-custom-viewer
+description: Guide to building your own custom log viewer inside your Laravel app on top of achyutn/filament-log-viewer — custom DTO, parsers, table, and viewers.
+license: MIT
+tags:
+  - filament
+  - laravel
+  - logs
+  - extensibility
+metadata:
+  author: Achyut Neupane
+---
+
+# Building a Custom Log Viewer in Your Application
+
+## Context
+
+You want a custom log viewer inside your Laravel app on top of `achyutn/filament-log-viewer` — your own data model/DTO, parser, table columns, stack-trace and mail viewers, and actions. Everything lives in your app's namespace (`App\...`) and is wired through the plugin's override methods. Two routes exist:
+
+- **Route A** — keep the `LogRow` array shape and reuse the default `LogTable`, swapping in your own provider, parser, schemas, and actions.
+- **Route B** — use a completely custom DTO/object shape and your own table design by supplying your own page.
+
+Both routes reuse the same contracts and plugin override methods.
+
+## The seams (recap)
+
+| Contract | Default | Plugin override |
+|---|---|---|
+| `LogProvider` | `LocalLogProvider` | `providerClass()` |
+| `LogParser` | `FileLogParser` | `parserClass()` |
+| `MailParser` | `DefaultMailParser` | `mailParserClass()` |
+| `StackTraceParser` | `DefaultStackTraceParser` | `stackTraceParserClass()` |
+| `LogViewerPage` | `LogTable` | `pageClass()` |
+| `CanDeleteLogs` | (implemented by `LocalLogProvider`) | — |
+| `LogTableSchemaInterface` | `LogTableSchema` | `tableSchemaClass()` |
+| `LogEntrySchemaInterface` | `ErrorLogSchema`, `JSONLogSchema`, `MailLogSchema` | `errorSchemaClass()`, `jsonSchemaClass()`, `mailSchemaClass()` |
+| `Filament\Actions\Action` | `CopyMarkdownAction` | `copyMarkdownActionClass()` |
+| — | `DateRangeFilter`, `FileFilter` | `dateRangeFilterClass()`, `fileFilterClass()` |
+
+Overrides are resolved through Laravel's service container (constructor dependencies auto-wire), and the plugin is a container singleton, so the classes apply app-wide rather than per-panel.
+
+---
+
+## Route A — keep the `LogRow` shape
+
+Use this when your data fits the `LogRow` array shape (`date`, `env`, `log_level`, `message`, `description`, `context`, `raw_stack`, `has_stack`, `mail`, `file`). You keep the default table and swap everything else.
+
+### 1. Implement your provider
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\LogProviders;
+
+use AchyutN\FilamentLogViewer\Contracts\CanDeleteLogs;
+use AchyutN\FilamentLogViewer\Contracts\LogProvider;
+use AchyutN\FilamentLogViewer\Enums\LogLevel;
+use App\Models\LogEntry;
+
+final class MyLogProvider implements LogProvider, CanDeleteLogs
+{
+    public function getRows(bool $refresh = false): array
+    {
+        // Map your store's entries into the LogRow array shape.
+        return LogEntry::query()->get()->map(
+            fn (LogEntry $entry): array => [
+                'date' => $entry->date,
+                'env' => $entry->env,
+                'log_level' => LogLevel::from($entry->level),
+                'message' => $entry->message,
+                'description' => $entry->description,
+                'context' => $entry->context,
+                'raw_stack' => $entry->raw_stack,
+                'has_stack' => $entry->has_stack,
+                'mail' => null,
+                'file' => $entry->channel,
+            ],
+        )->all();
+    }
+
+    public function getLogsByLevel(string $level): array
+    {
+        return array_values(array_filter(
+            $this->getRows(),
+            fn (array $row): bool => $row['log_level']->value === $level,
+        ));
+    }
+
+    public function getCount(string $level = 'all-logs'): ?int
+    {
+        return count($this->getRows()) ?: null;
+    }
+
+    public function getFiles(): array
+    {
+        return LogEntry::query()->distinct()->pluck('channel')->all();
+    }
+
+    public function getFilesForFilter(): array
+    {
+        return LogEntry::query()->distinct()->pluck('channel')->mapWithKeys(
+            fn (string $channel): array => [$channel => $channel],
+        )->all();
+    }
+
+    public function getStackFromRaw(string $rawStack): array
+    {
+        return [];
+    }
+
+    public function deleteAll(): void
+    {
+        LogEntry::query()->delete();
+    }
+
+    public function deleteFile(string $file): void
+    {
+        LogEntry::query()->where('channel', $file)->delete();
+    }
+}
+```
+
+### 2. Swap in your own schemas, actions, and filters
+
+```php
+use AchyutN\FilamentLogViewer\FilamentLogViewer;
+use App\LogParsers\MyLogParser;
+use App\LogParsers\MyMailParser;
+use App\LogParsers\MyStackParser;
+use App\LogProviders\MyLogProvider;
+use App\LogSchemas\MyErrorSchema;
+use App\LogSchemas\MyJsonSchema;
+use App\LogSchemas\MyMailSchema;
+use App\LogSchemas\MyTableSchema;
+
+FilamentLogViewer::make()
+    ->providerClass(MyLogProvider::class)
+    ->parserClass(MyLogParser::class)             // extends FileLogParser
+    ->mailParserClass(MyMailParser::class)        // extends DefaultMailParser
+    ->stackTraceParserClass(MyStackParser::class) // extends DefaultStackTraceParser
+    ->tableSchemaClass(MyTableSchema::class)       // implements LogTableSchemaInterface
+    ->errorSchemaClass(MyErrorSchema::class)       // implements LogEntrySchemaInterface
+    ->jsonSchemaClass(MyJsonSchema::class)
+    ->mailSchemaClass(MyMailSchema::class);
+```
+
+The table still renders the `LogRow` keys, but the columns, modals, and actions are yours. Parsers and schemas can be swapped individually — extend a default and override a single `protected` method, or implement the contract from scratch.
+
+---
+
+## Route B — custom DTO and your own table
+
+Use this when your data is a real object/DTO and you want your own columns. You supply your own page via `pageClass()` — the declared type is `class-string<LogTable>`, so the idiomatic path is to **extend `LogTable`**.
+
+### 1. Define your DTO
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+final class LogEntry
+{
+    public function __construct(
+        public readonly string $occurredAt,
+        public readonly string $channel,
+        public readonly string $level,
+        public readonly string $summary,
+        public readonly ?array $meta = null,
+    ) {}
+}
+```
+
+### 2. Implement your provider (returns your DTOs)
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\LogProviders;
+
+use AchyutN\FilamentLogViewer\Contracts\LogProvider;
+use App\Data\LogEntry;
+
+final class MyProvider implements LogProvider
+{
+    public function getRows(bool $refresh = false): array
+    {
+        return LogEntry::query()->get()->all(); // array<LogEntry>
+    }
+
+    public function getLogsByLevel(string $level): array
+    {
+        return array_values(array_filter(
+            $this->getRows(),
+            fn (LogEntry $entry): bool => $entry->level === $level,
+        ));
+    }
+
+    public function getCount(string $level = 'all-logs'): ?int
+    {
+        return count($this->getRows()) ?: null;
+    }
+
+    public function getFiles(): array
+    {
+        return LogEntry::query()->distinct()->pluck('channel')->all();
+    }
+
+    public function getFilesForFilter(): array
+    {
+        return LogEntry::query()->distinct()->pluck('channel')->mapWithKeys(
+            fn (string $channel): array => [$channel => $channel],
+        )->all();
+    }
+
+    public function getStackFromRaw(string $rawStack): array
+    {
+        return [];
+    }
+}
+```
+
+Implement `CanDeleteLogs` only if your store supports deletion (see the provider examples). Your page — not the plugin — decides how to render these objects.
+
+### 3. Build your page (extend `LogTable`)
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Pages;
+
+use AchyutN\FilamentLogViewer\LogTable;
+use App\LogProviders\MyProvider;
+use Filament\Tables\Table;
+use Filament\Tables\Columns\TextColumn;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+
+final class MyLogTable extends LogTable
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->records(
+                function (?array $filters, ?string $sortColumn, ?string $sortDirection, ?string $search, int $page, int $recordsPerPage): LengthAwarePaginator {
+                    /** @var array<int, \App\Data\LogEntry> $rows */
+                    $rows = app(MyProvider::class)->getRows();
+
+                    // Filter, sort, and paginate your DTOs here.
+                    $paginated = collect($rows)
+                        ->sortByDesc('occurredAt')
+                        ->forPage($page, $recordsPerPage);
+
+                    return new LengthAwarePaginator(
+                        $paginated,
+                        total: count($rows),
+                        perPage: $recordsPerPage,
+                        currentPage: $page,
+                    );
+                })
+            ->columns([
+                TextColumn::make('occurredAt')->label('Occurred')->since(),
+                TextColumn::make('channel')->label('Channel')->badge(),
+                TextColumn::make('level')->label('Level')->badge(),
+                TextColumn::make('summary')->label('Summary')->wrap(),
+            ])
+            ->recordActions([
+                // Your own row actions, e.g. an "inspect" slide-over.
+            ]);
+    }
+}
+```
+
+Because `MyLogTable extends LogTable`, it inherits the navigation, tabs, and header actions. Override any of the `protected` factory methods (`getViewAction()`, `getViewJsonAction()`, `getReadMailAction()`, `getDateRangeFilter()`, `getFileFilter()`, `getHeaderActions()`) to tailor them. You can also build a fresh Filament page implementing `HasTable`/`LogViewerPage` instead — the contracts do not force `LogTable`.
+
+### 4. Register everything in your panel provider
+
+```php
+use AchyutN\FilamentLogViewer\FilamentLogViewer;
+use App\Pages\MyLogTable;
+use App\LogProviders\MyProvider;
+
+return $panel->plugins([
+    FilamentLogViewer::make()
+        ->pageClass(MyLogTable::class)
+        ->providerClass(MyProvider::class)
+        ->navigationLabel('My Logs'),
+]);
+```
+
+## Notes
+
+- Overrides resolve through Laravel's service container, so constructor dependencies auto-wire.
+- The plugin is a container singleton, so the classes apply app-wide rather than per-panel.
+- Route B pages extend `LogTable` and keep the navigation/tabs/header-action machinery; the `LogRow` array shape is then irrelevant to your page because you define the columns.
+- `AchyutN\FilamentLogViewer\Model\Log` stays as a backward-compatible static facade; prefer the `LogProvider` contract in new code.
+- Write tests for your custom classes like any other Laravel code; the plugin's own suite covers the default wiring.
+
+## References
+
+- Skill: `resources/boost/skills/filament-log-viewer-development/SKILL.md`
+- Code examples: `references/code-examples.md`
+- Provider examples: `references/providers/read-only-provider.md`, `references/providers/database-provider.md`
+- Contracts: `src/Contracts/*`
+- Page: `src/LogTable.php`

--- a/resources/boost/skills/filament-log-viewer-development/references/providers/database-provider.md
+++ b/resources/boost/skills/filament-log-viewer-development/references/providers/database-provider.md
@@ -1,0 +1,120 @@
+---
+name: filament-log-viewer-database-provider
+description: Copy/paste example of a deletable database-backed LogProvider implementing CanDeleteLogs so the clear buttons operate on stored log rows.
+license: MIT
+tags:
+  - filament
+  - logs
+  - extensibility
+metadata:
+  author: Achyut Neupane
+---
+
+# Database Log Provider Example
+
+## Context
+
+A provider that can delete logs (e.g. a database-backed store) implements `LogProvider, CanDeleteLogs`. The **Clear Logs** and per-file clear buttons render and call `deleteAll()` / `deleteFile()`.
+
+> **What is "file" in a database provider?** The viewer's contracts and UI are keyed on a `file` field, but for a database-backed store that is really the **source/channel identifier** of each row (e.g. `laravel`, `scheduler`, `mail`). `CanDeleteLogs::deleteFile(string $file)` is named for the file-based provider, yet it operates on whatever source key you map into the `file` field — `deleteFile('laravel')` deletes every stored row for that source. Map the DB column into the required `LogRow['file']` field so the table's File column, file filter, and per-file clear dropdown all work.
+
+## Example
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\LogProviders;
+
+use AchyutN\FilamentLogViewer\Contracts\CanDeleteLogs;
+use AchyutN\FilamentLogViewer\Contracts\LogProvider;
+use App\Models\LogEntry;
+
+final class DatabaseLogProvider implements LogProvider, CanDeleteLogs
+{
+    public function getRows(bool $refresh = false): array
+    {
+        // Map stored rows into the LogRow array shape the table expects.
+        // 'file' here carries the source/channel identifier of each row.
+        return LogEntry::query()
+            ->get()
+            ->map(fn (LogEntry $entry): array => [
+                'date' => $entry->date,
+                'env' => $entry->env,
+                'log_level' => $entry->level,
+                'message' => $entry->message,
+                'description' => $entry->description,
+                'context' => $entry->context,
+                'raw_stack' => $entry->raw_stack,
+                'has_stack' => $entry->has_stack,
+                'mail' => null,
+                'file' => $entry->channel,
+            ])
+            ->all();
+    }
+
+    public function getLogsByLevel(string $level): array
+    {
+        return array_values(array_filter(
+            $this->getRows(),
+            fn (array $row): bool => $row['log_level']->value === $level,
+        ));
+    }
+
+    public function getCount(string $level = 'all-logs'): ?int
+    {
+        return count($this->getRows()) ?: null;
+    }
+
+    public function getFiles(): array
+    {
+        return LogEntry::query()->distinct()->pluck('channel')->all();
+    }
+
+    public function getFilesForFilter(): array
+    {
+        return LogEntry::query()->distinct()->pluck('channel')->mapWithKeys(
+            fn (string $channel): array => [$channel => $channel],
+        )->all();
+    }
+
+    public function getStackFromRaw(string $rawStack): array
+    {
+        return [];
+    }
+
+    public function deleteAll(): void
+    {
+        LogEntry::query()->delete();
+    }
+
+    public function deleteFile(string $file): void
+    {
+        // $file is the source/channel key per the CanDeleteLogs contract.
+        LogEntry::query()->where('channel', $file)->delete();
+    }
+}
+```
+
+Register it:
+
+```php
+use AchyutN\FilamentLogViewer\FilamentLogViewer;
+
+FilamentLogViewer::make()->providerClass(DatabaseLogProvider::class);
+```
+
+## Gotchas
+
+- `deleteFile(string $file)` receives the same key returned by `getFilesForFilter()` — keep both aligned on your source identifier.
+- Every row must match the `LogRow` array shape (`date`, `env`, `log_level`, `message`, `description`, `context`, `raw_stack`, `has_stack`, `mail`, `file`) for the default table to render it.
+- Constructor dependencies of your provider are auto-wired by Laravel's service container.
+- The plugin is a container singleton, so the provider applies app-wide rather than per-panel.
+
+## References
+
+- Contract: `src/Contracts/LogProvider.php`
+- Capability: `src/Contracts/CanDeleteLogs.php`
+- Default: `src/Providers/LocalLogProvider.php`
+- Skill: `resources/boost/skills/filament-log-viewer-development/SKILL.md`

--- a/resources/boost/skills/filament-log-viewer-development/references/providers/read-only-provider.md
+++ b/resources/boost/skills/filament-log-viewer-development/references/providers/read-only-provider.md
@@ -1,0 +1,83 @@
+---
+name: filament-log-viewer-read-only-provider
+description: Copy/paste example of a read-only LogProvider (cloud reader, Pail tail, or API stream) that omits CanDeleteLogs so the clear buttons stay hidden.
+license: MIT
+tags:
+  - filament
+  - logs
+  - extensibility
+metadata:
+  author: Achyut Neupane
+---
+
+# Read-Only Log Provider Example
+
+## Context
+
+A provider that only reads logs (e.g. a cloud reader, a Pail tail, or an API stream) should implement `LogProvider` and omit `CanDeleteLogs`. The **Clear Logs** and per-file clear buttons are then hidden automatically — no misleading delete actions.
+
+## Example
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\LogProviders;
+
+use AchyutN\FilamentLogViewer\Contracts\LogProvider;
+
+final class CloudLogProvider implements LogProvider
+{
+    public function getRows(bool $refresh = false): array
+    {
+        // Fetch rows from your API or stream.
+        return [];
+    }
+
+    public function getLogsByLevel(string $level): array
+    {
+        return $this->getRows();
+    }
+
+    public function getCount(string $level = 'all-logs'): ?int
+    {
+        return count($this->getRows()) ?: null;
+    }
+
+    public function getFiles(): array
+    {
+        return ['cloud.log'];
+    }
+
+    public function getFilesForFilter(): array
+    {
+        return ['cloud.log' => 'cloud.log'];
+    }
+
+    public function getStackFromRaw(string $rawStack): array
+    {
+        return [];
+    }
+}
+```
+
+Register it:
+
+```php
+use AchyutN\FilamentLogViewer\FilamentLogViewer;
+
+FilamentLogViewer::make()->providerClass(CloudLogProvider::class);
+```
+
+## Gotchas
+
+- Do not implement `CanDeleteLogs` on a read-only provider — it would show misleading clear buttons that cannot delete anything.
+- Constructor dependencies of your provider are auto-wired by Laravel's service container.
+- The plugin is a container singleton, so the provider applies app-wide rather than per-panel.
+
+## References
+
+- Contract: `src/Contracts/LogProvider.php`
+- Default: `src/Providers/LocalLogProvider.php`
+- Skill: `resources/boost/skills/filament-log-viewer-development/SKILL.md`


### PR DESCRIPTION
Documents the contract-driven architecture with an example for every contract, lists the Russian translation, and refreshes the configuration examples to cover the BackedEnum icon and disable_cache option.