### PR TITLE
fix: hides empty log files from filter and clear

### DIFF
--- a/src/Providers/LocalLogProvider.php
+++ b/src/Providers/LocalLogProvider.php
@@ -124,7 +124,7 @@ class LocalLogProvider implements CanDeleteLogs, LogProvider
      */
     public function getFiles(): array
     {
-        return $this->getAllLogFiles();
+        return $this->getFilesWithEntries();
     }
 
     /**
@@ -135,7 +135,7 @@ class LocalLogProvider implements CanDeleteLogs, LogProvider
         $initial = [];
 
         /** @var array<string, string|array<string, string>> */
-        return collect($this->getAllLogFiles())
+        return collect($this->getFilesWithEntries())
             ->reduce(function (array $carry, string $file): array {
                 if (str_contains($file, DIRECTORY_SEPARATOR)) {
                     $directory = dirname($file);
@@ -287,6 +287,21 @@ class LocalLogProvider implements CanDeleteLogs, LogProvider
         }
 
         return $files;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function getFilesWithEntries(): array
+    {
+        /** @var array<int, string> $files */
+        $files = [];
+
+        foreach ($this->getRows() as $row) {
+            $files[$row['file']] = $row['file'];
+        }
+
+        return array_values($files);
     }
 
     private function resetCache(): void

--- a/tests/Feature/LogTableTest.php
+++ b/tests/Feature/LogTableTest.php
@@ -147,6 +147,14 @@ describe('clear individual file', function () {
 
         filament('filament-log-viewer')->providerClass(LocalLogProvider::class);
     });
+
+    it('omits empty log files from the per-file clear dropdown', function () {
+        $this->writeLog('empty.log', '');
+
+        livewire(LogTable::class)
+            ->assertActionExists('clear-file-laravel-log')
+            ->assertActionDoesNotExist('clear-file-empty-log');
+    });
 });
 
 describe('columns', function () {
@@ -225,6 +233,16 @@ describe('filters', function () {
                     $filter->getLabel() === 'File' &&
                     $filter->getOptions() === Log::getFilesForFilter() &&
                     $filter->getIndicator() === 'File';
+            });
+    });
+
+    it('omits empty log files from the file filter options', function () {
+        $this->writeLog('empty.log', '');
+
+        livewire(LogTable::class)
+            ->assertTableFilterExists('file', function (SelectFilter $filter) {
+                return ! array_key_exists('empty.log', $filter->getOptions()) &&
+                    array_key_exists('laravel.log', $filter->getOptions());
             });
     });
 

--- a/tests/Unit/LocalLogProviderTest.php
+++ b/tests/Unit/LocalLogProviderTest.php
@@ -124,6 +124,17 @@ describe('LocalLogProvider - files', function () {
         expect($files)->toHaveKey('laravel.log');
         expect($files)->toHaveKey('stack-trace.log');
     });
+
+    it('excludes empty log files from getFiles and getFilesForFilter', function () {
+        $this->writeLog('empty.log', '');
+
+        $files = makeProvider()->getFiles();
+        $filterFiles = makeProvider()->getFilesForFilter();
+
+        expect($files)->not->toContain('empty.log');
+        expect($filterFiles)->not->toHaveKey('empty.log');
+        expect($files)->toContain('laravel.log');
+    });
 });
 
 describe('LocalLogProvider - deleteAll', function () {


### PR DESCRIPTION
Derives `getFiles` and `getFilesForFilter` from parsed rows instead of the raw filesystem scan, so log files with zero entries no longer appear in the file filter or the per-file clear dropdown. `deleteAll` still truncates every log file.