### PR TITLE
fix: supports 'all' pagination option

### DIFF
--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -83,11 +83,14 @@ class LogTable extends Page implements HasTable
                     $records = filled($sortColumn)
                         ? $records->sortBy($sortColumn, SORT_DESC, $sortDirection === 'desc')
                         : $records->sortByDesc('date');
-                    // Filament allows 'all' as a pagination option: resolve any
-                    // non-integer option to the total record count, mirroring
-                    // CanPaginateRecords. Guard against zero so the paginator
-                    // never receives perPage: 0 on empty tables.
-                    $perPage = is_int($recordsPerPage) ? $recordsPerPage : max(count($records), 1);
+                    // Filament allows 'all' as a pagination option: resolve it to the
+                    // total record count, mirroring CanPaginateRecords. Anything
+                    // else is cast to int because browsers submit select values
+                    // (even numeric ones) as strings. Guard against zero so the
+                    // paginator never receives perPage: 0 on empty tables.
+                    $perPage = $recordsPerPage === 'all'
+                        ? max(count($records), 1)
+                        : max((int) $recordsPerPage, 1);
                     $paginatedRecords = $records
                         ->forPage($page, $perPage);
 

--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -83,10 +83,11 @@ class LogTable extends Page implements HasTable
                     $records = filled($sortColumn)
                         ? $records->sortBy($sortColumn, SORT_DESC, $sortDirection === 'desc')
                         : $records->sortByDesc('date');
-                    // Filament allows 'all' as a pagination option: resolve it to the
-                    // total record count, mirroring CanPaginateRecords. Guard against
-                    // zero so the paginator never receives perPage: 0 on empty tables.
-                    $perPage = $recordsPerPage === 'all' ? max(count($records), 1) : $recordsPerPage;
+                    // Filament allows 'all' as a pagination option: resolve any
+                    // non-integer option to the total record count, mirroring
+                    // CanPaginateRecords. Guard against zero so the paginator
+                    // never receives perPage: 0 on empty tables.
+                    $perPage = is_int($recordsPerPage) ? $recordsPerPage : max(count($records), 1);
                     $paginatedRecords = $records
                         ->forPage($page, $perPage);
 

--- a/src/LogTable.php
+++ b/src/LogTable.php
@@ -70,7 +70,7 @@ class LogTable extends Page implements HasTable
             ->modelLabel(__('filament-log-viewer::log.table.model_label'))
             ->pluralModelLabel(__('filament-log-viewer::log.table.plural_model_label'))
             ->records(
-                function (?array $filters, ?string $sortColumn, ?string $sortDirection, ?string $search, int $page, int $recordsPerPage): LengthAwarePaginator {
+                function (?array $filters, ?string $sortColumn, ?string $sortDirection, ?string $search, int $page, int|string $recordsPerPage): LengthAwarePaginator {
                     /** @var LogProvider $provider */
                     $provider = app(LogProvider::class);
                     $records = Collection::wrap($provider->getRows());
@@ -83,13 +83,17 @@ class LogTable extends Page implements HasTable
                     $records = filled($sortColumn)
                         ? $records->sortBy($sortColumn, SORT_DESC, $sortDirection === 'desc')
                         : $records->sortByDesc('date');
+                    // Filament allows 'all' as a pagination option: resolve it to the
+                    // total record count, mirroring CanPaginateRecords. Guard against
+                    // zero so the paginator never receives perPage: 0 on empty tables.
+                    $perPage = $recordsPerPage === 'all' ? max(count($records), 1) : $recordsPerPage;
                     $paginatedRecords = $records
-                        ->forPage($page, $recordsPerPage);
+                        ->forPage($page, $perPage);
 
                     return new LengthAwarePaginator(
                         $paginatedRecords,
                         total: count($records),
-                        perPage: $recordsPerPage,
+                        perPage: $perPage,
                         currentPage: $page,
                     );
                 })

--- a/tests/Feature/LogTableTest.php
+++ b/tests/Feature/LogTableTest.php
@@ -374,4 +374,31 @@ describe('pagination', function () {
             ->and($paginator->perPage())->toBe(2)
             ->and($paginator->items())->toHaveCount(2);
     });
+
+    it('treats numeric strings like browsers submit them', function () {
+        $paginator = livewire(LogTable::class)
+            ->set('tableRecordsPerPage', '2')
+            ->assertSuccessful()
+            ->instance()
+            ->getTableRecords();
+
+        expect($paginator)->toBeInstanceOf(LengthAwarePaginator::class)
+            ->and($paginator->total())->toBe(4)
+            ->and($paginator->perPage())->toBe(2)
+            ->and($paginator->items())->toHaveCount(2);
+    });
+
+    it("shows an empty page instead of crashing for 'all' without logs", function () {
+        $this->deleteAllLogs();
+
+        $paginator = livewire(LogTable::class)
+            ->set('tableRecordsPerPage', 'all')
+            ->assertSuccessful()
+            ->instance()
+            ->getTableRecords();
+
+        expect($paginator)->toBeInstanceOf(LengthAwarePaginator::class)
+            ->and($paginator->total())->toBe(0)
+            ->and($paginator->items())->toBeEmpty();
+    });
 });

--- a/tests/Feature/LogTableTest.php
+++ b/tests/Feature/LogTableTest.php
@@ -18,6 +18,7 @@ use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\SelectFilter;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 use function Pest\Livewire\livewire;
 
@@ -344,5 +345,33 @@ describe('record actions (slide-over regression)', function () {
         livewire(LogTable::class)
             ->mountTableAction('view', '0')
             ->assertSuccessful();
+    });
+});
+
+describe('pagination', function () {
+    it("accepts the 'all' records-per-page option", function () {
+        $paginator = livewire(LogTable::class)
+            ->set('tableRecordsPerPage', 'all')
+            ->assertSuccessful()
+            ->instance()
+            ->getTableRecords();
+
+        expect($paginator)->toBeInstanceOf(LengthAwarePaginator::class)
+            ->and($paginator->total())->toBe(4)
+            ->and($paginator->perPage())->toBe(4)
+            ->and($paginator->items())->toHaveCount(4);
+    });
+
+    it('paginates with an integer option', function () {
+        $paginator = livewire(LogTable::class)
+            ->set('tableRecordsPerPage', 2)
+            ->assertSuccessful()
+            ->instance()
+            ->getTableRecords();
+
+        expect($paginator)->toBeInstanceOf(LengthAwarePaginator::class)
+            ->and($paginator->total())->toBe(4)
+            ->and($paginator->perPage())->toBe(2)
+            ->and($paginator->items())->toHaveCount(2);
     });
 });


### PR DESCRIPTION
Fixes #131.

Accepts Filament's string 'all' records-per-page value in the LogTable records closure and resolves it to the total record count, mirroring CanPaginateRecords. Previously the int type-hint threw a TypeError that persisted via session and locked users out. Guards empty tables so the paginator never receives perPage 0.